### PR TITLE
feat: loading animation while llm is working

### DIFF
--- a/changelog.d/9.added.md
+++ b/changelog.d/9.added.md
@@ -1,0 +1,1 @@
+Loading animation while llm is working

--- a/deu_ruim/llm/agents.py
+++ b/deu_ruim/llm/agents.py
@@ -71,6 +71,9 @@ async def validate_result(
     if isinstance(response, FixerFail):
         return response
 
+    ctx.deps.progress.update(
+        ctx.deps.task_id, description='Validating command...'
+    )
     validator_response = await ctx.deps.validator_agent.run(
         response.fixed_command
     )

--- a/deu_ruim/llm/deps.py
+++ b/deu_ruim/llm/deps.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 from pydantic_ai import Agent
+from rich.progress import Progress, TaskID
 
 from deu_ruim.llm.schemas import ValidatorResponse
 
@@ -8,3 +9,5 @@ from deu_ruim.llm.schemas import ValidatorResponse
 @dataclass
 class FixerDeps:
     validator_agent: Agent[None, ValidatorResponse]
+    progress: Progress
+    task_id: TaskID


### PR DESCRIPTION
# Deu Ruim Pull Request

Thanks for your interest in **Deu Ruim**!!

If your changes introduce breaking changes, please prefix the title of your pull request with "[BREAKING_CHANGES]". This allows for clear identification of such changes in the 'What's Changed' section on the release page, making it developer-friendly.

Please follow these instructions, fill every question, and complete every step.

## First Check

Please confirm and check all the following options:

- [x] I added a very descriptive title here.
- [x] If this is a breaking change, I added the `[BREAKING_CHANGES]` prefix on the title.
- [x] I already searched for a similar [pull request](https://github.com/RWallan/deu-ruim/pulls).
- [x] I tested all my changes.

## Describe the change

Added a spinner animation while LLM is working. This allows the user to know what's going on.

## Describe the solution

Used the `Progress` from rich to add a progress bar and customized with `SpinnerColumn` and `TextColumn` to create a template.

## Additional context

It needed a hack to properly closes the progress and show the click confirmation.

```python
# cli.py

# ...
@app.default
async def deu_ruim(cmd: str, *, verbose: bool = False):
    # ...
    
    # HACK: Must stop progress explicity otherwise `click.confirm` will not show
    progress.stop()
    
    # ...
```

closes #9

